### PR TITLE
fix LoadELF call

### DIFF
--- a/src/pyrenode3/wrappers/machine.py
+++ b/src/pyrenode3/wrappers/machine.py
@@ -40,7 +40,7 @@ class Machine(Wrapper):
         location : str
             path or url to ELF file.
         """
-        FileLoaderExtensions.LoadELF(self.sysbus.internal, RPath(location).read_file_path)
+        self.sysbus.internal.LoadELF(RPath(location).read_file_path)
 
     def load_binary(self, location: str, load_point: int) -> None:
         """Load binary from URL or local filesystem.


### PR DESCRIPTION
Issue happens with renode_v1.15.3 built on my own under windows 11 with gcc and dotnet