### PR TITLE
Fix PYRENODE_BIN with relative paths

### DIFF
--- a/src/pyrenode3/loader.py
+++ b/src/pyrenode3/loader.py
@@ -242,7 +242,7 @@ class RenodeLoader(metaclass=MetaSingleton):
     @classmethod
     def from_net_bin(cls, path: "Union[str, pathlib.Path]"):
         """Load Renode from binary."""
-        renode_bin = pathlib.Path(path)
+        renode_bin = pathlib.Path(path).resolve()
         renode_dir = renode_bin.parent
 
         # As a side effect, executing the binary causes the embedded dlls to be extracted to:

--- a/src/pyrenode3/loader.py
+++ b/src/pyrenode3/loader.py
@@ -346,7 +346,7 @@ class RenodeLoader(metaclass=MetaSingleton):
     @classmethod
     def from_net_bin(cls, path: "Union[str, pathlib.Path]", temp=None):
         """Load Renode from binary."""
-        renode_bin = pathlib.Path(path)
+        renode_bin = pathlib.Path(path).resolve()
         renode_dir = renode_bin.parent
 
         # From 18.06.2026 Renode packages are not built as a 'SingleFile' package.


### PR DESCRIPTION
In from_net_bin() convert the path to absolute (resolving any symlinks and relative components), so all downstream symlinks created from renode_dir will use absolute paths regardless of how PYRENODE_BIN was set.